### PR TITLE
AVDump3NativeLib non-Linux UNIX portability fixes and macOS build

### DIFF
--- a/.github/workflows/AVDump3.yml
+++ b/.github/workflows/AVDump3.yml
@@ -14,28 +14,27 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        #os: [windows-latest, ubuntu-latest, macos-latest]
-        os: [windows-latest, ubuntu-latest]
+        os: [windows-latest, ubuntu-latest, macos-latest]
         include: 
         - os: windows-latest
           platform: windows
         - os: ubuntu-latest
           platform: linux
-        #- os: macos-latest
-        #  platform: macos
+        - os: macos-latest
+          platform: macos
           
     steps:
     - name: AVD3Native-Checkout
       uses: actions/checkout@v2.1.0
 
-    - name: AVD3Native-Compile-LinuxOrMacOS
-      if: matrix.platform == 'linux' ||  matrix.platform == 'macos'
+    - name: AVD3Native-Compile-Linux
+      if: matrix.platform == 'linux'
       run: |         
         make -C AVDump3NativeLib
         mv ${{ github.workspace }}/AVDump3NativeLib/AVDump3NativeLib.so ${{ github.workspace }}/AVDump3NativeLib/AVDump3NativeLib-x64.so
 
-    - name: AVD3Native-ArtifactUpload-LinuxOrMacOS
-      if: matrix.platform == 'linux' ||  matrix.platform == 'macos'
+    - name: AVD3Native-ArtifactUpload-Linux
+      if: matrix.platform == 'linux'
       uses: actions/upload-artifact@v2
       with:
         name: AVDump3NativeLib.Linux
@@ -56,6 +55,23 @@ jobs:
       with:
         name: AVDump3NativeLib.Linux
         path: ${{ github.workspace }}/AVDump3NativeLib/AVDump3NativeLib-aarch64.so
+
+    - name: AVD3Native-Compile-MacOS
+      if: matrix.platform == 'macos'
+      run: |
+        # Match .NET Core's macOS target versions
+        make ARCH=x86_64 -C AVDump3NativeLib MACOSX_DEPLOYMENT_TARGET=10.13
+        mv ${{ github.workspace }}/AVDump3NativeLib/AVDump3NativeLib.dylib ${{ github.workspace }}/AVDump3NativeLib/AVDump3NativeLib-x64.dylib
+        make -B ARCH=arm64 -C AVDump3NativeLib MACOSX_DEPLOYMENT_TARGET=11.0
+        mv ${{ github.workspace }}/AVDump3NativeLib/AVDump3NativeLib.dylib ${{ github.workspace }}/AVDump3NativeLib/AVDump3NativeLib-arm64.dylib
+        lipo -create ${{ github.workspace }}/AVDump3NativeLib/AVDump3NativeLib-{x64,arm64}.dylib -output ${{ github.workspace }}/AVDump3NativeLib/AVDump3NativeLib.dylib
+
+    - name: AVD3Native-ArtifactUpload-MacOS
+      if: matrix.platform == 'macos'
+      uses: actions/upload-artifact@v2
+      with:
+        name: AVDump3NativeLib.MacOS
+        path: ${{ github.workspace }}/AVDump3NativeLib/AVDump3NativeLib.dylib
 
     - name: AVD3Native-MSBuildSetup-Windows
       if: matrix.platform == 'windows'

--- a/AVDump3NativeLib/Makefile
+++ b/AVDump3NativeLib/Makefile
@@ -1,6 +1,16 @@
 ARCH ?= $(shell uname -m)
+SYS ?= $(shell uname -s)
 
+SOEXT = .so
+
+ifeq ($(SYS),Linux)
 CC = $(ARCH)-linux-gnu-gcc
+else ifeq ($(SYS),Darwin)
+CC = cc -arch $(ARCH)
+SOEXT = .dylib
+else
+CC = cc
+endif
 
 CFLAGS=-I. -Wall -Werror -fpic -O3
 OBJ = AVD3MirrorBuffer.o AVD3NativeLibApi.o InstructionCheck.o CRC32.o MD4.o SHA3.o Tiger.o
@@ -17,7 +27,7 @@ $(OBJ_SSE4): SSE4_FLAGS := -msse4
 $(OBJ_SHA): SHA_FLAGS := -msha
 endif
 
-AVDump3NativeLib.so: $(OBJ)
+AVDump3NativeLib$(SOEXT): $(OBJ)
 	$(CC) -shared -o $@ $^ $(CFLAGS)
 
 %.o: src/%.c

--- a/AVDump3NativeLib/Makefile
+++ b/AVDump3NativeLib/Makefile
@@ -2,7 +2,7 @@ ARCH ?= $(shell uname -m)
 
 CC = $(ARCH)-linux-gnu-gcc
 
-CFLAGS=-I. -Wall -Werror -fpic -O3 -lrt
+CFLAGS=-I. -Wall -Werror -fpic -O3
 OBJ = AVD3MirrorBuffer.o AVD3NativeLibApi.o InstructionCheck.o CRC32.o MD4.o SHA3.o Tiger.o
 
 SSE4_FLAGS :=

--- a/AVDump3NativeLib/src/AVD3MirrorBuffer.c
+++ b/AVDump3NativeLib/src/AVD3MirrorBuffer.c
@@ -21,7 +21,7 @@ char* CreateMirrorBuffer(uint32_t minLength, AVD3MirrorBufferCreateHandle* handl
 	int success = shm_unlink(path);
 	if (success != 0) return "shm_unlink returned non-zero";
 
-	success = ftruncate(fd, length);
+	success = ftruncate(fd, length * 2);
 	if (success != 0) return "ftruncate returned non-zero";
 
 	uint8_t* data = mmap(0, length * 2, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);

--- a/AVDump3NativeLib/src/AVD3MirrorBuffer.c
+++ b/AVDump3NativeLib/src/AVD3MirrorBuffer.c
@@ -1,64 +1,6 @@
 #define _GNU_SOURCE
 #include "AVD3NativeLibApi.h"
 
-#ifdef __unix__
-
-#include <stdio.h>
-#include <assert.h>
-#include <fcntl.h>
-#include <unistd.h>
-#include <sys/mman.h>
-#include <sys/stat.h>
-#include <errno.h>
-
-char* CreateMirrorBuffer(uint32_t minLength, AVD3MirrorBufferCreateHandle* handle) {
-	uint32_t pageSize = getpagesize();
-
-	uint32_t pageCount = minLength / pageSize + (minLength % pageSize == 0 ? 0 : 1);
-	if (pageCount > UINT32_MAX / pageSize / 2) return "requested length is too big";
-	uint32_t length = pageCount * pageSize;
-
-	char path[] = "/AVD3WrapAroundBuffer";
-	int fd = shm_open(path, O_RDWR | O_CREAT | O_EXCL, 0600);
-	if (fd == -1) return "shm_open returned -1";
-	int success = shm_unlink(path);
-	if (success != 0) return "shm_unlink returned non-zero";
-
-	success = ftruncate(fd, length * 2);
-	if (success != 0) return "ftruncate returned non-zero";
-
-	uint8_t* data = mmap(0, length * 2, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
-	if (data == (void*)-1)return "mmap (first) returned -1";
-
-	uint8_t* mirror = mmap(data + length, length, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_FIXED, fd, 0);
-	if (mirror == (void*)-1) {
-		if (munmap(data, length) != 0) return "munmap returned non-zero";
-		return "mmap (second) returned -1";
-	}
-
-	close(fd);
-
-	for (size_t i = 0; i < length; i++) {
-		data[i] = (uint8_t)i;
-		if (data[i] != mirror[i]) return "Data Mirroring failed";
-		data[i] = 0;
-	}
-
-	handle->fileHandle = 0;
-	handle->baseAddress = data;
-	handle->length = length;
-
-	return 0;
-}
-
-char* FreeMirrorBuffer(AVD3MirrorBufferCreateHandle * handle) {
-
-	return 0;
-}
-
-#endif
-
-
 #ifdef _WIN32
 
 #include <Windows.h>
@@ -114,6 +56,61 @@ char* FreeMirrorBuffer(AVD3MirrorBufferCreateHandle* handle) {
 	if (!UnmapViewOfFile(handle->baseAddress)) return "First UnmapViewOfFile failed";
 	if (!UnmapViewOfFile(handle->baseAddress + handle->length)) return "Second UnmapViewOfFile failed";
 	if (!CloseHandle(handle->fileHandle)) return "CloseHandle failed";
+	return 0;
+}
+
+#else
+
+#include <stdio.h>
+#include <assert.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <errno.h>
+
+char* CreateMirrorBuffer(uint32_t minLength, AVD3MirrorBufferCreateHandle* handle) {
+	uint32_t pageSize = getpagesize();
+
+	uint32_t pageCount = minLength / pageSize + (minLength % pageSize == 0 ? 0 : 1);
+	if (pageCount > UINT32_MAX / pageSize / 2) return "requested length is too big";
+	uint32_t length = pageCount * pageSize;
+
+	char path[] = "/AVD3WrapAroundBuffer";
+	int fd = shm_open(path, O_RDWR | O_CREAT | O_EXCL, 0600);
+	if (fd == -1) return "shm_open returned -1";
+	int success = shm_unlink(path);
+	if (success != 0) return "shm_unlink returned non-zero";
+
+	success = ftruncate(fd, length * 2);
+	if (success != 0) return "ftruncate returned non-zero";
+
+	uint8_t* data = mmap(0, length * 2, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+	if (data == (void*)-1)return "mmap (first) returned -1";
+
+	uint8_t* mirror = mmap(data + length, length, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_FIXED, fd, 0);
+	if (mirror == (void*)-1) {
+		if (munmap(data, length) != 0) return "munmap returned non-zero";
+		return "mmap (second) returned -1";
+	}
+
+	close(fd);
+
+	for (size_t i = 0; i < length; i++) {
+		data[i] = (uint8_t)i;
+		if (data[i] != mirror[i]) return "Data Mirroring failed";
+		data[i] = 0;
+	}
+
+	handle->fileHandle = 0;
+	handle->baseAddress = data;
+	handle->length = length;
+
+	return 0;
+}
+
+char* FreeMirrorBuffer(AVD3MirrorBufferCreateHandle * handle) {
+
 	return 0;
 }
 

--- a/AVDump3NativeLib/src/AVD3MirrorBuffer.c
+++ b/AVDump3NativeLib/src/AVD3MirrorBuffer.c
@@ -13,7 +13,10 @@
 
 char* CreateMirrorBuffer(uint32_t minLength, AVD3MirrorBufferCreateHandle* handle) {
 	uint32_t pageSize = getpagesize();
-	uint32_t length = (minLength / pageSize + (minLength % pageSize == 0 ? 0 : 1)) * pageSize;
+
+	uint32_t pageCount = minLength / pageSize + (minLength % pageSize == 0 ? 0 : 1);
+	if (pageCount > UINT32_MAX / pageSize / 2) return "requested length is too big";
+	uint32_t length = pageCount * pageSize;
 
 	char path[] = "/AVD3WrapAroundBuffer";
 	int fd = shm_open(path, O_RDWR | O_CREAT | O_EXCL, 0600);
@@ -66,7 +69,9 @@ char* CreateMirrorBuffer(uint32_t minLength, AVD3MirrorBufferCreateHandle * hand
 	uint32_t pageSize = sysInfo.dwAllocationGranularity;
 	if (pageSize <= 0) return "GetSystemInfo dwAllocationGranularity is zero or negative";
 
-	uint32_t length = (minLength / pageSize + (minLength % pageSize == 0 ? 0 : 1)) * pageSize;
+	uint32_t pageCount = minLength / pageSize + (minLength % pageSize == 0 ? 0 : 1);
+	if (pageCount > UINT32_MAX / pageSize / 2) return "requested length is too big";
+	uint32_t length = pageCount * pageSize;
 
 	HANDLE fileMappingHandle = CreateFileMapping(INVALID_HANDLE_VALUE, 0, PAGE_READWRITE, 0, length, NULL);
 	if (fileMappingHandle == NULL) return "CreateFileMapping returned NULL";

--- a/AVDump3NativeLib/src/AVD3NativeLibApi.h
+++ b/AVDump3NativeLib/src/AVD3NativeLibApi.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <string.h>
-#include <malloc.h>
 #include <stdint.h>
+#include <stdlib.h>
 
 #if defined(_M_X64) || defined(__x86_64__)
 #include <nmmintrin.h>
@@ -83,7 +83,6 @@ DLL_PUBLIC char* FreeMirrorBuffer(AVD3MirrorBufferCreateHandle* handle);
 //https://github.com/google/cityhash/blob/8af9b8c2b889d80c22d6bc26ba0df1afb79a30db/src/city.cc#L50
 #ifdef _MSC_VER
 
-#include <stdlib.h>
 #define bswap_32(x) _byteswap_ulong(x)
 #define bswap_64(x) _byteswap_uint64(x)
 


### PR DESCRIPTION
This builds for me on old macOS (10.13, 64-bit Intel) and on old Linux (although I have to set `CC` explicitly, because `x86_64-linux-gnu-gcc` doesn’t exist for me: it’d be best to avoid hardcoding this name, but I presume it’s done like this for the sake of GitHub CI and I don’t know enough about GitHub CI to change it to something else on my own).

This runs for me on macOS 10.13 with a freshly installed `dotnet`, but I’m seeing two problems:
* There’s no MediaInfo. Obviously. Do you need help building one? I can assist for Intel if you tell me how you make the builds, but I don’t have an ARM compiler.
* My terminal is left messed up every time I run the app, no matter whether it crashes for any reason or successfully prints the help/usage page. I’m unable to test on Linux at the moment (no .NET Core) to see if it happens there as well. The cursor remains hidden, and cursor movement seems messed up. I have to run `reset` to return to a usable state (and I’m not even sure that that fully fixes it).

Ideally, the MediaInfo build should be moved into this very repository’s GitHub CI. That would make it transparent as users would know how the binaries come to be, automated, and reproducible. Users on platforms where you don’t provide a prebuilt MediaInfo could also build one on their own. Even if you just download someone else’s builds, you could still do the downloading in GitHub CI or a build/maintaner script, or at least leave a human-readable note explaining this.

Speaking of portability:
* On macOS, it tends to be even easier to end up with binaries that won’t work on older macOS versions. You may think that’s fine and I can’t stop you, but do know there are still people (me, for one!) running old versions who’d appreciate being able to run AVDump3. I believe I’ve taken care of this for AVDump3NativeLib; see my GitHub CI changes. You’d need to similarly define `MACOSX_DEPLOYMENT_TARGET` or provide `-mmacosx-version-min` when building MediaInfo. That _should_ be all that’s needed, but I can’t promise that MediaInfo or its dependencies don’t override this.
* I see the Linux x86-64 binaries use a symbol from glibc 2.14. Without a doubt, 2.14 is old by now, and this poses no problem for modern Linux distros. But hey, if you could [somehow avoid that](https://github.com/wheybags/glibc_version_header), it could be used even on more-ancient distros such as RHEL/CentOS 6 or Wheezy. Then again, I don’t know what glibcs .NET Core runs on.
* The MediaInfo library also uses symbols from libgcc_s and libstdc++. On the one hand, those seem even older; on the other, I imagine barebones/embedded distros may not have them at all. It would be best to ask GCC to link those statically with `-static-libgcc -static-libstdc++`.
* In fact, glibc itself may be absent. In particular, .NET Core officially supports Alpine Linux, which uses musl and lacks glibc as a first-class citizen. It is _possible_ to install glibc on Alpine, but it would be more awesome if this wasn’t necessary. It may be possible for you to build MediaInfo and AVDump3NativeLib with static linking (`-static`) against glibc, and indeed if that doesn’t work, it should be possible for you to build them with static linking against musl instead. The binaries would likely get somewhat bigger, but they’d almost surely run on any Linux anywhere.