### PR TITLE
Make Native project use v143

### DIFF
--- a/AVDump3Lib/AVDump3Lib.csproj
+++ b/AVDump3Lib/AVDump3Lib.csproj
@@ -39,7 +39,6 @@
     <PackageReference Include="ExtKnot.StringInvariants" Version="1.0.4-alpha" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.1.0-1.final" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AVDump3NativeLib/AVDump3NativeLib.vcxproj
+++ b/AVDump3NativeLib/AVDump3NativeLib.vcxproj
@@ -23,14 +23,14 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <PreferredToolArchitecture>x64</PreferredToolArchitecture>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
     <PreferredToolArchitecture>x64</PreferredToolArchitecture>
@@ -38,7 +38,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='GithubWorkflow|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
     <PreferredToolArchitecture>x64</PreferredToolArchitecture>
@@ -82,8 +82,8 @@
       <LanguageStandard_C>Default</LanguageStandard_C>
     </ClCompile>
     <PostBuildEvent>
-      <Command>copy /Y "$(OutDir)AVD*.dll" "$(SolutionDir)AVDump3CL\bin\$(PlatformName)\$(ConfigurationName)\net6.0\"
-copy /Y "$(OutDir)AVD*.pdb" "$(SolutionDir)AVDump3CL\bin\$(PlatformName)\$(ConfigurationName)\net6.0\"
+      <Command>copy /Y "$(OutDir)AVD*.dll" "$(SolutionDir)AVDump3CL\bin\$(ConfigurationName)\net6.0\"
+copy /Y "$(OutDir)AVD*.pdb" "$(SolutionDir)AVDump3CL\bin\$(ConfigurationName)\net6.0\"
 </Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
@@ -107,8 +107,8 @@ copy /Y "$(OutDir)AVD*.pdb" "$(SolutionDir)AVDump3CL\bin\$(PlatformName)\$(Confi
       <Profile>true</Profile>
     </Link>
     <PostBuildEvent>
-      <Command>copy /Y "$(OutDir)*.dll" "$(SolutionDir)AVDump3CL\bin\$(PlatformName)\$(ConfigurationName)\net6.0\"
-copy /Y "$(OutDir)*.pdb" "$(SolutionDir)AVDump3CL\bin\$(PlatformName)\$(ConfigurationName)\net6.0\"
+      <Command>copy /Y "$(OutDir)*.dll" "$(SolutionDir)AVDump3CL\bin\$(ConfigurationName)\net6.0\"
+copy /Y "$(OutDir)*.pdb" "$(SolutionDir)AVDump3CL\bin\$(ConfigurationName)\net6.0\"
 </Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>


### PR DESCRIPTION
so that all required frameworks are installed from one Build Tools (2022).
Remove unused reference to Serilog in Lib in preparation for Nuget deployment