### PR TITLE
Fix output redirection on windows + more

### DIFF
--- a/AVDump3CL/AVD3Console.cs
+++ b/AVDump3CL/AVD3Console.cs
@@ -235,7 +235,7 @@ public class AVD3Console : IDisposable, IAVD3Console {
 						//}
 						if(lines[j].Length < progressBuilder.DisplayWidth) {
 							progressBuilder.Buffer.Append(' ', progressBuilder.DisplayWidth - lines[j].Length);
-						} else if(lines[j].Length >= progressBuilder.ConsoleWidth) {
+						} else if(progressBuilder.DisplayWidth != 0 && lines[j].Length >= progressBuilder.ConsoleWidth) {
 							progressBuilder.Buffer.Append(' ', Math.Max(0, progressBuilder.DisplayWidth - 2 - lines[j].Length % progressBuilder.DisplayWidth));
 						}
 

--- a/AVDump3CL/AVD3Console.cs
+++ b/AVDump3CL/AVD3Console.cs
@@ -130,7 +130,7 @@ public class AVD3Console : IDisposable, IAVD3Console {
 
 	private readonly bool canManipulateCursor;
 	private int displaySkipCount;
-	private int maxTopCursorPos;
+	private int maxTopCursorPos = 0;
 	private int jitterDisplayUpdateCount;
 	private readonly Stopwatch perfWatch = new();
 
@@ -177,12 +177,13 @@ public class AVD3Console : IDisposable, IAVD3Console {
 				progressBuilder.MarkFinished();
 
 				progressBuilder.Reset(this);
-				var cursorTop = Console.CursorTop;
+				var cursorTop = canManipulateCursor ? Console.CursorTop : 0;
 				for(int i = cursorTop; i < maxTopCursorPos; i++) {
 					progressBuilder.AppendLine();
 				}
 				Console.Write(progressBuilder.Buffer);
-				Console.SetCursorPosition(0, cursorTop);
+				if (canManipulateCursor)
+					Console.SetCursorPosition(0, cursorTop);
 			}
 		}
 	}
@@ -208,8 +209,11 @@ public class AVD3Console : IDisposable, IAVD3Console {
 			var progressLineCountPrev = progressBuilder.ProgressLineCount;
 			progressBuilder.Reset(this);
 
-			maxTopCursorPos = Math.Max(maxTopCursorPos, Console.CursorTop);
-			Console.SetCursorPosition(0, Math.Max(0, Console.CursorTop - progressLineCountPrev));
+			if (canManipulateCursor)
+			{
+				maxTopCursorPos = Math.Max(maxTopCursorPos, Console.CursorTop);
+				Console.SetCursorPosition(0, Math.Max(0, Console.CursorTop - progressLineCountPrev));
+			}
 
 			string[] toWrite;
 			lock(this.toWrite) {
@@ -290,10 +294,12 @@ public class AVD3Console : IDisposable, IAVD3Console {
 	public IDisposable LockConsole() {
 		progressTimer.Change(Timeout.Infinite, Timeout.Infinite);
 		Monitor.Enter(progressWriteLock);
-		Console.SetCursorPosition(0, maxTopCursorPos);
+		if (canManipulateCursor)
+			Console.SetCursorPosition(0, maxTopCursorPos);
 
 		return new ProxyDisposable(() => {
-			maxTopCursorPos = Math.Max(maxTopCursorPos, Console.CursorTop);
+			if (canManipulateCursor)
+				maxTopCursorPos = Math.Max(maxTopCursorPos, Console.CursorTop);
 			Monitor.Exit(progressWriteLock);
 			progressTimer.Change(500, TickPeriod);
 		});


### PR DESCRIPTION
Running `AVDump3CL.exe` on Windows in a sub-process with output redirection currently leads to AVDump3 erring out every time it tries to manipulate the cursor since the cursor manipulation on Windows uses WinAPIs and requires a console window to function, which is not available for sub-process ran in C# with output redirection enabled. I'll also note that this is not a problem on linux, just on windows.

This PR fixes the issue by just not trying to manipulate the cursor position if we cannot manipulate the cursor checking the pre-existing `canManipulateCursor` property before trying to do any cursor manipulation in the console class.

The error that is repeated over and over on standard output;
```log
Unhandled exception. System.IO.IOException: The handle is invalid.
at System.ConsolePal.GetBufferInfo(Boolean throwOnNoConsole, Boolean& succeeded)
at System.ConsolePal.GetCursorPosition()
at AVDump3CL.AVD3Console.OnWriteProgress(Object _)
at System.Threading.TimerQueueTimer.<>c.<.cctor>b__27_0(Object state)
at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location ---
at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
at System.Threading.TimerQueueTimer.CallCallback(Boolean isThreadPool)
at System.Threading.TimerQueueTimer.Fire(Boolean isThreadPool)
at System.Threading.TimerQueue.FireNextTimers()
at System.Threading.TimerQueue.AppDomainTimerCallback(Int32 id)
Unhandled exception. System.IO.IOException: The handle is invalid.
at System.ConsolePal.GetBufferInfo(Boolean throwOnNoConsole, Boolean& succeeded)
at System.ConsolePal.GetCursorPosition()
at AVDump3CL.AVD3Console.OnWriteProgress(Object _)
at System.Threading.TimerQueueTimer.<>c.<.cctor>b__27_0(Object state)
at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location ---
at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
at System.Threading.TimerQueueTimer.CallCallback(Boolean isThreadPool)
at System.Threading.TimerQueueTimer.Fire(Boolean isThreadPool)
at System.Threading.TimerQueue.FireNextTimers()
at System.Threading.TimerQueue.AppDomainTimerCallback(Int32 id)
```